### PR TITLE
--use-docker-for-pt オプションの修正

### DIFF
--- a/anemoeater
+++ b/anemoeater
@@ -70,7 +70,7 @@ our $pt_qd;
 if ($opt->{pt_docker})
 {
   system("sudo docker pull yoku0825/percona-toolkit > /dev/null");
-  $pt_qd= "sudo docker run yoku0825/percona-toolkit pt-query-digest";
+  $pt_qd= "sudo docker run -i yoku0825/percona-toolkit pt-query-digest";
 }
 else
 {


### PR DESCRIPTION
`--use-docker-for-pt` オプションを利用する際に、docker run の `-i` オプションがないために stdin がつながっていないようです。

その結果、時間区切りにされた slow_log がうまく渡されずに期待どおりに動いてませんでしたので修正しています。