### PR TITLE
sprintf の警告が出ないように修正

### DIFF
--- a/anemoeater
+++ b/anemoeater
@@ -179,7 +179,7 @@ foreach my $file (@files)
         ### normalize without seconds.
         $timetmp= sprintf("20%02d%02d%02d%02d%02d",
                           $+{year}, $+{month}, $+{day},
-                          $+{hour}, $+{minute}, $+{second});
+                          $+{hour}, $+{minute});
   
       }
       elsif ($+{timestr} =~ /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})T
@@ -192,7 +192,7 @@ foreach my $file (@files)
         ### normalize without seconds.
         $timetmp= sprintf("%04d%02d%02d%02d%02d",
                           $+{year}, $+{month}, $+{day},
-                          $+{hour}, $+{minute}, $+{second});
+                          $+{hour}, $+{minute});
         
         ### replace buffer's timestr.
         $_= sprintf("# Time: %02d%02d%02d %2d:%02d:%02d\n",


### PR DESCRIPTION
## 概要

anemoeater 実行時に以下の最終行のような警告が表示されます。

```console
$ ./anemoeater --use-docker-for-pt ./slowlog56.log
Docker container starts with 172.17.0.2.
URL will be http://127.0.0.1:32768/anemometer
Redundant argument in sprintf at ./anemoeater line 183, <$in> line 7.  <<== 警告
```

## 原因

Perl 5.22 以降では `use warnings;` している場合に、 `sprintf()` や `printf()` で format が必要とするものより多くの引数が指定されていると警告が出るようになったようです。（[perl v5.22.0 での変更点](http://perldoc.jp/docs/perl/5.22.0/perl5220delta.pod#New32Warnings) の `Redundant argument in %s` に概要があります。下記に引用しておきます。）


[perl5220delta - perl v5.22.0 での変更点 - perldoc.jp](http://perldoc.jp/docs/perl/5.22.0/perl5220delta.pod#New32Warnings) より
> Redundant argument in %s
>
> (W redundant) (例えば printf フォーマットのような) 指定された他の引数の中の 情報で指定された、関数が必要としているよりも多くの引数で関数を呼び出しました。 現在のところこの警告は、printf 形式のフォーマットが要求するよりも多い数の 引数が指定されたときにのみ出力されますが、将来は (例えば "pack" in perlfunc のような) 他のものに使われるかも知れません。
>
> 警告カテゴリ redundant は新しいものです。 [perl #121025] も 参照してください。

## 対策

該当する `sprintf()` で不要な引数を削除しています。