### PR TITLE
Ignore system schema

### DIFF
--- a/anemoeater
+++ b/anemoeater
@@ -19,7 +19,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 ########################################################################
 
-use constant VERSION => "0.0.3";
+use constant VERSION => "0.0.4";
 use strict;
 use warnings;
 use utf8;
@@ -153,8 +153,7 @@ $pt_dsn  .= sprintf(",P=%d", $opt->{port})     if $opt->{port};
 $pt_dsn  .= sprintf(",u=%s", $opt->{user})     if $opt->{user};
 $pt_dsn  .= sprintf(",p=%s", $opt->{password}) if $opt->{password};
 
-my $cmd_format= qq{| %s --type=%s --no-version-check --review %s --history %s --no-report --limit=0%% --filter="\\\$event->{Bytes} = length(\\\$event->{arg}) and \\\$event->{hostname}='%s'" > /dev/null};
-
+my $cmd_format= q{| %s --type=%s --no-version-check --review %s --history %s --no-report --limit=0%% --filter='$event->{Bytes} = length($event->{arg}) and $event->{hostname}="%s" and ($event->{db} || "") !~ /^(information_schema|performance_schema|sys)/' > /dev/null};
 
 my $pm  = Parallel::ForkManager->new($opt->{parallel});
 

--- a/anemoeater
+++ b/anemoeater
@@ -153,7 +153,7 @@ $pt_dsn  .= sprintf(",P=%d", $opt->{port})     if $opt->{port};
 $pt_dsn  .= sprintf(",u=%s", $opt->{user})     if $opt->{user};
 $pt_dsn  .= sprintf(",p=%s", $opt->{password}) if $opt->{password};
 
-my $cmd_format= q{| %s --type=%s --no-version-check --review %s --history %s --no-report --limit=0%% --filter='$event->{Bytes} = length($event->{arg}) and $event->{hostname}="%s" and ($event->{db} || "") !~ /^(information_schema|performance_schema|sys)/' > /dev/null};
+my $cmd_format= q{| %s --type=%s --no-version-check --review %s --history %s --no-report --limit=0%% --filter='$event->{Bytes} = length($event->{arg}) and $event->{hostname}="%s" and ($event->{db} || "") !~ /^(information_schema|performance_schema|sys)$/ and !(!(defined($event->{db})) and ($event->{fingerprint} || "") =~ /\s(information_schema|performance_schema|sys)\./)' > /dev/null};
 
 my $pm  = Parallel::ForkManager->new($opt->{parallel});
 

--- a/anemoeater
+++ b/anemoeater
@@ -153,7 +153,7 @@ $pt_dsn  .= sprintf(",P=%d", $opt->{port})     if $opt->{port};
 $pt_dsn  .= sprintf(",u=%s", $opt->{user})     if $opt->{user};
 $pt_dsn  .= sprintf(",p=%s", $opt->{password}) if $opt->{password};
 
-my $cmd_format= q{| %s --type=%s --no-version-check --review %s --history %s --no-report --limit=0%% --filter='$event->{Bytes} = length($event->{arg}) and $event->{hostname}="%s" and ($event->{db} || "") !~ /^(information_schema|performance_schema|sys)$/ and !(!(defined($event->{db})) and ($event->{fingerprint} || "") =~ /\s(information_schema|performance_schema|sys)\./)' > /dev/null};
+my $cmd_format= q{| %s --type=%s --no-version-check --review %s --history %s --no-report --limit=0%% --filter='$event->{Bytes} = length($event->{arg}) and $event->{hostname}="%s" and ($event->{db} || "") !~ /^(information_schema|performance_schema|sys)$/ and (($event->{fingerprint} || "") !~ /\s(information_schema|performance_schema|sys)\./)' > /dev/null};
 
 my $pm  = Parallel::ForkManager->new($opt->{parallel});
 


### PR DESCRIPTION
[i_rethi](https://twitter.com/i_rethi) has suggested as below.

```
prometheusのmysqld_exporterのモニタリングクエリがテーブルスキャンになるから log-queries-not-using-indexes が有効な環境だとスロークエリとして記録されちゃうです。
```